### PR TITLE
Fix Error in Template File

### DIFF
--- a/nativetemplates/src/main/java/com/google/android/ads/nativetemplates/TemplateView.java
+++ b/nativetemplates/src/main/java/com/google/android/ads/nativetemplates/TemplateView.java
@@ -31,6 +31,7 @@ import android.widget.TextView;
 import androidx.annotation.Nullable;
 import androidx.annotation.RequiresApi;
 import androidx.constraintlayout.widget.ConstraintLayout;
+import com.google.ads.nativetemplates.R;
 import com.google.android.gms.ads.formats.MediaView;
 import com.google.android.gms.ads.formats.NativeAd.Image;
 import com.google.android.gms.ads.formats.UnifiedNativeAd;


### PR DESCRIPTION
Got an error "R" not found in app. Fix it by adding 
import com.google.ads.nativetemplates.R;
to the file.